### PR TITLE
upgrade devise to remove security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-gem 'devise'
+gem 'devise', '>= 4.7.1'
 
 #bootstrap
 gem 'bootstrap', '~> 4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,8 +53,7 @@ GEM
     arel (9.0.0)
     autoprefixer-rails (9.4.8)
       execjs
-    bcrypt (3.1.12)
-    bcrypt (3.1.12-x64-mingw32)
+    bcrypt (3.1.13)
     bindex (0.5.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
@@ -94,10 +93,10 @@ GEM
     debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
-    devise (4.6.1)
+    devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 6.0)
+      railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
@@ -275,9 +274,9 @@ GEM
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     retriable (3.1.2)
     rly (0.2.3)
     rspec-core (3.8.0)
@@ -386,7 +385,7 @@ DEPENDENCIES
   chartjs-ror
   chromedriver-helper (= 1.2.0)
   coffee-rails (~> 4.2)
-  devise
+  devise (>= 4.7.1)
   google-cloud-storage (~> 1.11)
   jbuilder (~> 2.5)
   jquery-rails


### PR DESCRIPTION
There's a security vulnerability with devise, and this bumps up the version to fix that.